### PR TITLE
Make the crate no_std-compatible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! [internal_macros.rs]: https://github.com/rust-lang/rust/blob/master/library/core/src/internal_macros.rs
 
+#![no_std]
+
 /// Extend a unary operator trait impl over refs.
 ///
 /// Given an implementation of `op T` where T is `Copy`able, implements the unary


### PR DESCRIPTION
Even though the crate doesn’t use std crate, because it doesn’t
declare `#![no_std]` it cannot be compiled in no_std environments:

    error[E0463]: can't find crate for `std`
      = note: the `thumbv6m-none-eabi` target may not support the standard library
      = note: `std` is required by `forward_ref` because it does not declare `#![no_std]`

Adding the annotation makes it possible to use the crate on no_std
targets.

Issue: https://github.com/CosmWasm/cosmwasm/issues/1484
